### PR TITLE
Fix setup script.

### DIFF
--- a/setup-unix-build.sh
+++ b/setup-unix-build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 GREEN='\033[0;32m'
 NC='\033[0m' # No Color
 


### PR DESCRIPTION
There is nothing bash-specific in this script, so it needlessly breaks the build on system that do not install bash by default, such as the BSDs.